### PR TITLE
Change /account route to redirect to new Primo My Account page

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,11 @@ Rails.application.routes.draw do
   get 'users/account', :as => :user_account
   get 'users/account/show' => 'users#account_render', :as => :user_account_render
   get 'users/tags', :as => :user_tags
-  get 'account' => 'users#account', :as => :account
+  get 'account',
+    # Copied from UsersHelper.bobcat_account_url:
+    # https://github.com/NYULibraries/eshelf/blob/9d8966e342072ea58142482906ff2c5c393e7684/app/helpers/users_helper.rb#L19
+    to: redirect(URI.escape("#{ENV['PRIMO_BASE_URL']}/primo-explore/account?vid=NYU&section=overview")),
+    :as => :account
 
   resources :records, :except => [:new, :edit, :destroy] do
     get 'print/:print_format' => 'records#print', :on => :collection, :as => :print


### PR DESCRIPTION
This is an initial deployment for monday.com ticket [Retire old my account pages](https://nyu-lib.monday.com/boards/765008773/views/61942705/pulses/2743047345).

The associated tests/refactorings/code pruning has not been done yet, but we need to roll this change out today. 
 See [comment in monday.com ticket](https://nyu-lib.monday.com/boards/765008773/pulses/2743047345/posts/1679097510).