### PR TITLE
Add RSpec test of redirect from /account route to Primo My Library Account

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,41 +1,11 @@
-# The users controller manages a user's account and tags,
-# and offers a set of actions:
-#   - :account - wraps the display of the user's Aleph account as html
+# The users controller manages a user's tags, offers one action:
 #   - :tags - display the list of user tags as html, json or xml
 #
 # Author::    scotdalton
 # Copyright:: Copyright (c) 2013 New York University
 # License::   Distributes under the same terms as Ruby
 class UsersController < ApplicationController
-  respond_to :json, :xml, except: :account
-  respond_to :html
-
-  # Display the Aleph account for the current user.
-  def account_render
-    unless current_user.nil?
-      respond_with(current_user) do |format|
-        format.html { render :account }
-      end
-    else
-      redirect_to user_account_path(account_params)
-    end
-  end
-
-  def account
-    # Log into PDS directly since that is required
-    # for the Aleph account option
-    if !cookies[:_pds_logged_in].present?
-      cookies[:_return_to_account] = true
-      cookies[:_pds_logged_in] = true
-      cookies[:_account_primary_institution] = account_params[:institution]
-      redirect_to pds_login
-    elsif cookies[:_pds_logged_in]
-      cookies.delete(:_pds_logged_in)
-      redirect_to user_account_render_path(account_params)
-    else
-      head :bad_request
-    end
-  end
+  respond_to :json, :html, :xml
 
   # Display the tags for the current user.
   def tags
@@ -47,15 +17,4 @@ class UsersController < ApplicationController
     end
     respond_with(@tags)
   end
-
-  private
-
-  def account_params
-    params.permit(:institution).select { |k,v| k === :institution.to_s }
-  end
-
-  def pds_login
-    "#{ENV['PDS_URL']}/pds?func=load-login&institute=#{current_primary_institution.code}&calling_system=eshelf&url=#{CGI::escape(passive_login_url)}"
-  end
-
 end

--- a/app/views/users/account.html.erb
+++ b/app/views/users/account.html.erb
@@ -1,2 +1,0 @@
-<p><%= link_to "Trouble loading? Click here to view your account", "https://aleph.library.nyu.edu/F?func=bor-info" %> </p>
-<%= tag(:iframe, id: "aleph_account", src: aleph_account_url, sandbox: 'allow-same-origin allow-scripts allow-forms') unless current_user.nil? %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,8 +2,6 @@ Rails.application.routes.draw do
   # The priority is based upon order of creation: first created -> highest priority.
   # See how all your routes lay out with "rake routes".
 
-  get 'users/account', :as => :user_account
-  get 'users/account/show' => 'users#account_render', :as => :user_account_render
   get 'users/tags', :as => :user_tags
   get 'account',
     # Copied from UsersHelper.bobcat_account_url:

--- a/spec/routing/redirects_to_external_urls_spec.rb
+++ b/spec/routing/redirects_to_external_urls_spec.rb
@@ -1,0 +1,6 @@
+RSpec.describe "GET /account", :type => :request do
+  it "redirects to Primo My Library Account" do
+    get "/account"
+    expect(response).to redirect_to(URI.escape("#{ENV['PRIMO_BASE_URL']}/primo-explore/account?vid=NYU&section=overview"))
+  end
+end

--- a/test/functional/users_controller_test.rb
+++ b/test/functional/users_controller_test.rb
@@ -15,21 +15,6 @@ class UsersControllerTest < ActionController::TestCase
     @request.cookies["_pds_logged_in"] = true
   end
 
-  test "should get account" do
-    sign_in @user
-    get :account
-    assert_response :redirect
-    assert_redirected_to user_account_render_url
-    assert_nil cookies["_pds_logged_in"]
-  end
-
-  test "should render account" do
-    sign_in @user
-    get :account_render
-    assert_response :success
-    assert_select "iframe", 1
-  end
-
   test "should get tags" do
     skip
     sign_in @user


### PR DESCRIPTION
This PR adds the test of the new redirect from /account to Primo My Library Account.

monday.com: [Retire old my account pages](https://nyu-lib.monday.com/boards/765008773/views/61942705/pulses/2743047345).
